### PR TITLE
[FEAT]: Add beast evolution

### DIFF
--- a/dojo/README.md
+++ b/dojo/README.md
@@ -1,28 +1,6 @@
-![Dojo Starter](./assets/cover.png)
+![HORIZONTAL 1](https://github.com/user-attachments/assets/23cf4504-95b4-492a-ab0d-1e98ffd79154)
 
-<picture>
-  <source media="(prefers-color-scheme: dark)" srcset=".github/mark-dark.svg">
-  <img alt="Dojo logo" align="right" width="120" src=".github/mark-light.svg">
-</picture>
-
-<a href="https://twitter.com/dojostarknet">
-<img src="https://img.shields.io/twitter/follow/dojostarknet?style=social"/>
-</a>
-<a href="https://github.com/dojoengine/dojo">
-<img src="https://img.shields.io/github/stars/dojoengine/dojo?style=social"/>
-</a>
-
-[![discord](https://img.shields.io/badge/join-dojo-green?logo=discord&logoColor=white)](https://discord.gg/PwDa2mKhR4)
-[![Telegram Chat][tg-badge]][tg-url]
-
-[tg-badge]: https://img.shields.io/endpoint?color=neon&logo=telegram&label=chat&style=flat-square&url=https%3A%2F%2Ftg.sumanjay.workers.dev%2Fdojoengine
-[tg-url]: https://t.me/dojoengine
-
-# Dojo Starter: Official Guide
-
-A quickstart guide to help you build and deploy your first Dojo provable game.
-
-Read the full tutorial [here](https://dojoengine.org/tutorial/dojo-starter).
+# BabyBeast Dojo Engine
 
 ## Running Locally
 
@@ -47,19 +25,3 @@ sozo migrate
 torii --world <WORLD_ADDRESS> --allowed-origins "*"
 ```
 
----
-
-## Contribution
-
-1. **Report a Bug**
-
-    - If you think you have encountered a bug, and we should know about it, feel free to report it [here](https://github.com/dojoengine/dojo-starter/issues) and we will take care of it.
-
-2. **Request a Feature**
-
-    - You can also request for a feature [here](https://github.com/dojoengine/dojo-starter/issues), and if it's viable, it will be picked for development.
-
-3. **Create a Pull Request**
-    - It can't get better then this, your pull request will be appreciated by the community.
-
-Happy coding!

--- a/dojo/src/constants.cairo
+++ b/dojo/src/constants.cairo
@@ -9,3 +9,6 @@ const MAX_TAP_COUNTER: u32 = 10;
 
 // Max food amount per player
 const MAX_FOOD_AMOUNT: u32 = 10;
+
+// Max level as babybeast
+const MAX_BABY_LEVEL: u32 = 15;

--- a/dojo/src/models/beast.cairo
+++ b/dojo/src/models/beast.cairo
@@ -15,5 +15,6 @@ pub struct Beast {
     pub specie: u32,
     pub status: BeastStatus,
     pub stats: BeastStats,
-    pub evolved: bool
+    pub evolved: bool,
+    pub vaulted: bool
 }

--- a/dojo/src/models/beast.cairo
+++ b/dojo/src/models/beast.cairo
@@ -14,5 +14,6 @@ pub struct Beast {
     pub beast_id: u32,
     pub specie: u32,
     pub status: BeastStatus,
-    pub stats: BeastStats
+    pub stats: BeastStats,
+    pub evolved: bool
 }

--- a/dojo/src/systems/actions.cairo
+++ b/dojo/src/systems/actions.cairo
@@ -141,7 +141,8 @@ pub mod actions {
                 specie: specie,
                 status: initial_beast_status,
                 stats: initial_beast_stats,
-                evolved: false
+                evolved: false,
+                vaulted: false
             };
 
             self.beast_counter.write(current_beast_id+1);
@@ -279,6 +280,7 @@ pub mod actions {
                     // Evolution level reached
                     if beast.stats.level >= constants::MAX_BABY_LEVEL {
                         beast.evolved = true;
+                        beast.vaulted = true;
                     }
                     beast.stats.experience = 0;
                     beast.stats.next_level_experience = beast.stats.next_level_experience + 20;
@@ -311,6 +313,7 @@ pub mod actions {
                     // Evolution level reached
                     if beast.stats.level >= constants::MAX_BABY_LEVEL {
                         beast.evolved = true;
+                        beast.vaulted = true;
                     }
                     beast.stats.experience = 0;
                     beast.stats.next_level_experience = beast.stats.next_level_experience + 20;

--- a/dojo/src/systems/actions.cairo
+++ b/dojo/src/systems/actions.cairo
@@ -140,7 +140,8 @@ pub mod actions {
                 beast_id: current_beast_id,
                 specie: specie,
                 status: initial_beast_status,
-                stats: initial_beast_stats
+                stats: initial_beast_stats,
+                evolved: false
             };
 
             self.beast_counter.write(current_beast_id+1);
@@ -275,6 +276,10 @@ pub mod actions {
                 beast.stats.experience = beast.stats.experience + 10;
                 if beast.stats.experience >= beast.stats.next_level_experience {
                     beast.stats.level = beast.stats.level + 1;
+                    // Evolution level reached
+                    if beast.stats.level >= constants::MAX_BABY_LEVEL {
+                        beast.evolved = true;
+                    }
                     beast.stats.experience = 0;
                     beast.stats.next_level_experience = beast.stats.next_level_experience + 20;
                 }
@@ -303,6 +308,10 @@ pub mod actions {
                 beast.stats.experience = beast.stats.experience + 10;
                 if beast.stats.experience >= beast.stats.next_level_experience {
                     beast.stats.level = beast.stats.level + 1;
+                    // Evolution level reached
+                    if beast.stats.level >= constants::MAX_BABY_LEVEL {
+                        beast.evolved = true;
+                    }
                     beast.stats.experience = 0;
                     beast.stats.next_level_experience = beast.stats.next_level_experience + 20;
                     beast.stats.attack = beast.stats.attack + 1;

--- a/dojo/src/systems/actions.cairo
+++ b/dojo/src/systems/actions.cairo
@@ -15,6 +15,7 @@ trait IActions<T> {
     fn clean(ref self: T);
     fn revive(ref self: T);
     // Other methods
+    fn init_tap_counter(ref self: T);
     fn tap(ref self: T, specie: u32);
 }
 
@@ -22,6 +23,7 @@ trait IActions<T> {
 pub mod actions {
     // Starknet imports
     use starknet::{ContractAddress, get_caller_address};
+    use starknet::storage::{Map, StorageMapReadAccess, StorageMapWriteAccess};
     
     // Local import
     use super::{IActions};
@@ -47,13 +49,12 @@ pub mod actions {
     #[storage]
     struct Storage {
         beast_counter: u32,
-        tap_counter: u32
+        tap_counter: Map<ContractAddress, u32>
     }
 
     // Constructor
     fn dojo_init( ref self: ContractState) {
         self.beast_counter.write(1);
-        self.tap_counter.write(0);
     }
 
     // Implementation of the interface methods
@@ -67,6 +68,8 @@ pub mod actions {
                 address: caller, 
                 current_beast_id: 0
             };
+
+            self.init_tap_counter();
             world.write_model(@new_player);
         }
 
@@ -364,14 +367,23 @@ pub mod actions {
             }
         }
 
+        fn init_tap_counter(ref self: ContractState) {
+            let player_address = get_caller_address();
+
+            self.tap_counter.write(player_address, 0);
+        }
+
+
         fn tap(ref self: ContractState, specie: u32) {
-            let current_tap_counter = self.tap_counter.read();
+            let player_address = get_caller_address();
+            let current_tap_counter = self.tap_counter.read(player_address);
 
             if current_tap_counter == constants::MAX_TAP_COUNTER {
                 self.spawn(specie);
+                self.init_tap_counter();
             }
 
-            self.tap_counter.write(current_tap_counter+1);
+            self.tap_counter.write(player_address, current_tap_counter+1);
         }
     }
 }


### PR DESCRIPTION
## Summary  
-  Closes #98 
- This PR implements the logic for **beast evolution** once it reaches level 15.  
  - Sets `vaulted` and `evolved` values to `true`, preventing further in-game use.  

## Extras  
- Improved player-specific tap counter handling for better accuracy and consistency.