### PR TITLE
[FEAT]: Add unit tests for models/types

### DIFF
--- a/dojo/src/models/beast.cairo
+++ b/dojo/src/models/beast.cairo
@@ -18,3 +18,228 @@ pub struct Beast {
     pub evolved: bool,
     pub vaulted: bool
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Beast;
+    use super::BeastStats;
+    use super::BeastStatus;
+    use starknet::contract_address_const;
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_beast_initialization() {
+        let player_address = contract_address_const::<0x123>();
+        
+        let beast_status = BeastStatus {
+            beast_id: 1_u32,
+            is_alive: true,
+            is_awake: true,
+            hunger: 100_u32,
+            energy: 100_u32,
+            happiness: 100_u32,
+            hygiene: 100_u32,
+        };
+
+        let beast_stats = BeastStats {
+            beast_id: 1_u32,
+            attack: 10_u32,
+            defense: 10_u32,
+            speed: 10_u32,
+            level: 1_u32,
+            experience: 0_u32,
+            next_level_experience: 100_u32,
+        };
+
+        let beast = Beast {
+            player: player_address,
+            beast_id: 1_u32,
+            specie: 1_u32,
+            status: beast_status,
+            stats: beast_stats,
+            evolved: false,
+            vaulted: false,
+        };
+
+        assert_eq!(beast.player, player_address, "Player address should match");
+        assert_eq!(beast.beast_id, 1_u32, "Beast ID should be 1");
+        assert_eq!(beast.specie, 1_u32, "Specie should be 1");
+        assert!(!beast.evolved, "Beast should not be evolved initially");
+        assert!(!beast.vaulted, "Beast should not be vaulted initially");
+
+        assert!(beast.status.is_alive, "Beast should be alive");
+        assert!(beast.status.is_awake, "Beast should be awake");
+        assert_eq!(beast.status.energy, 100_u32, "Beast should have full energy");
+
+        assert_eq!(beast.stats.level, 1_u32, "Beast should be level 1");
+        assert_eq!(beast.stats.experience, 0_u32, "Beast should have 0 experience");
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_multiple_beasts_per_player() {
+        let player_address = contract_address_const::<0x123>();
+        
+        let beast1 = Beast {
+            player: player_address,
+            beast_id: 1_u32,
+            specie: 1_u32,
+            status: BeastStatus {
+                beast_id: 1_u32,
+                is_alive: true,
+                is_awake: true,
+                hunger: 100_u32,
+                energy: 100_u32,
+                happiness: 100_u32,
+                hygiene: 100_u32,
+            },
+            stats: BeastStats {
+                beast_id: 1_u32,
+                attack: 10_u32,
+                defense: 10_u32,
+                speed: 10_u32,
+                level: 1_u32,
+                experience: 0_u32,
+                next_level_experience: 100_u32,
+            },
+            evolved: false,
+            vaulted: false,
+        };
+
+        let beast2 = Beast {
+            player: player_address,
+            beast_id: 2_u32,
+            specie: 2_u32,
+            status: BeastStatus {
+                beast_id: 2_u32,
+                is_alive: true,
+                is_awake: true,
+                hunger: 100_u32,
+                energy: 100_u32,
+                happiness: 100_u32,
+                hygiene: 100_u32,
+            },
+            stats: BeastStats {
+                beast_id: 2_u32,
+                attack: 12_u32,
+                defense: 12_u32,
+                speed: 12_u32,
+                level: 1_u32,
+                experience: 0_u32,
+                next_level_experience: 100_u32,
+            },
+            evolved: false,
+            vaulted: false,
+        };
+
+        assert_eq!(beast1.player, beast2.player, "Beasts should belong to same player");
+        assert!(beast1.beast_id != beast2.beast_id, "Beasts should have different IDs");
+        assert!(beast1.specie != beast2.specie, "Beasts should be different species");
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_evolved_beast() {
+        let player_address = contract_address_const::<0x123>();
+        
+        let evolved_beast = Beast {
+            player: player_address,
+            beast_id: 1_u32,
+            specie: 1_u32,
+            status: BeastStatus {
+                beast_id: 1_u32,
+                is_alive: true,
+                is_awake: true,
+                hunger: 100_u32,
+                energy: 100_u32,
+                happiness: 100_u32,
+                hygiene: 100_u32,
+            },
+            stats: BeastStats {
+                beast_id: 1_u32,
+                attack: 20_u32,
+                defense: 20_u32,
+                speed: 20_u32,
+                level: 10_u32,
+                experience: 1000_u32,
+                next_level_experience: 1200_u32,
+            },
+            evolved: true,
+            vaulted: false,
+        };
+
+        assert!(evolved_beast.evolved, "Beast should be evolved");
+        assert!(evolved_beast.stats.attack > 10_u32, "Evolved beast should have higher attack");
+        assert!(evolved_beast.stats.level >= 10_u32, "Evolved beast should be higher level");
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_vaulted_beast() {
+        let player_address = contract_address_const::<0x123>();
+        
+        let vaulted_beast = Beast {
+            player: player_address,
+            beast_id: 1_u32,
+            specie: 1_u32,
+            status: BeastStatus {
+                beast_id: 1_u32,
+                is_alive: true,
+                is_awake: false,  
+                hunger: 100_u32,
+                energy: 100_u32,
+                happiness: 100_u32,
+                hygiene: 100_u32,
+            },
+            stats: BeastStats {
+                beast_id: 1_u32,
+                attack: 10_u32,
+                defense: 10_u32,
+                speed: 10_u32,
+                level: 1_u32,
+                experience: 0_u32,
+                next_level_experience: 100_u32,
+            },
+            evolved: false,
+            vaulted: true,
+        };
+
+        assert!(vaulted_beast.vaulted, "Beast should be vaulted");
+        assert!(vaulted_beast.status.is_alive, "Vaulted beast should still be alive");
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_beast_id_consistency() {
+        let player_address = contract_address_const::<0x123>();
+        
+        let beast = Beast {
+            player: player_address,
+            beast_id: 1_u32,
+            specie: 1_u32,
+            status: BeastStatus {
+                beast_id: 1_u32,  
+                is_alive: true,
+                is_awake: true,
+                hunger: 100_u32,
+                energy: 100_u32,
+                happiness: 100_u32,
+                hygiene: 100_u32,
+            },
+            stats: BeastStats {
+                beast_id: 1_u32,  
+                attack: 10_u32,
+                defense: 10_u32,
+                speed: 10_u32,
+                level: 1_u32,
+                experience: 0_u32,
+                next_level_experience: 100_u32,
+            },
+            evolved: false,
+            vaulted: false,
+        };
+
+        assert_eq!(beast.beast_id, beast.status.beast_id, "Beast ID should match status ID");
+        assert_eq!(beast.beast_id, beast.stats.beast_id, "Beast ID should match stats ID");
+    }
+}

--- a/dojo/src/models/beast_stats.cairo
+++ b/dojo/src/models/beast_stats.cairo
@@ -13,3 +13,126 @@ pub struct BeastStats {
     pub experience: u32,
     pub next_level_experience: u32,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::BeastStats;
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_beast_stats_initialization() {
+        let beast_stats = BeastStats {
+            beast_id: 1_u32,
+            attack: 10_u32,
+            defense: 10_u32,
+            speed: 10_u32,
+            level: 1_u32,
+            experience: 0_u32,
+            next_level_experience: 100_u32,
+        };
+
+        assert_eq!(beast_stats.beast_id, 1_u32, "Beast ID should be 1");
+        assert_eq!(beast_stats.attack, 10_u32, "Initial attack should be 10");
+        assert_eq!(beast_stats.defense, 10_u32, "Initial defense should be 10");
+        assert_eq!(beast_stats.speed, 10_u32, "Initial speed should be 10");
+        assert_eq!(beast_stats.level, 1_u32, "Initial level should be 1");
+        assert_eq!(beast_stats.experience, 0_u32, "Initial experience should be 0");
+        assert_eq!(beast_stats.next_level_experience, 100_u32, "Initial next level experience should be 100");
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_beast_stats_different_levels() {
+        let beast_level_1 = BeastStats {
+            beast_id: 1_u32,
+            attack: 10_u32,
+            defense: 10_u32,
+            speed: 10_u32,
+            level: 1_u32,
+            experience: 0_u32,
+            next_level_experience: 100_u32,
+        };
+
+        let beast_level_5 = BeastStats {
+            beast_id: 2_u32,
+            attack: 25_u32,
+            defense: 25_u32,
+            speed: 25_u32,
+            level: 5_u32,
+            experience: 400_u32,
+            next_level_experience: 500_u32,
+        };
+
+        assert!(beast_level_1.level < beast_level_5.level, "Higher level beast should have greater level");
+        assert!(beast_level_1.attack < beast_level_5.attack, "Higher level beast should have greater attack");
+        assert!(beast_level_1.next_level_experience < beast_level_5.next_level_experience, "Higher level beast should have greater next level experience requirement");
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_beast_stats_experience_system() {
+        let beast_stats = BeastStats {
+            beast_id: 1_u32,
+            attack: 15_u32,
+            defense: 15_u32,
+            speed: 15_u32,
+            level: 2_u32,
+            experience: 75_u32,
+            next_level_experience: 200_u32,
+        };
+
+        assert!(
+            beast_stats.experience < beast_stats.next_level_experience,"Current experience should be less than next level requirement"
+        );
+
+        assert!(beast_stats.next_level_experience > 0_u32, "Next level experience should be positive");
+        assert!(beast_stats.level > 0_u32, "Level should be positive");
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_beast_stats_unique_ids() {
+        let beast1 = BeastStats {
+            beast_id: 1_u32,
+            attack: 10_u32,
+            defense: 10_u32,
+            speed: 10_u32,
+            level: 1_u32,
+            experience: 0_u32,
+            next_level_experience: 100_u32,
+        };
+
+        let beast2 = BeastStats {
+            beast_id: 2_u32,
+            attack: 10_u32,
+            defense: 10_u32,
+            speed: 10_u32,
+            level: 1_u32,
+            experience: 0_u32,
+            next_level_experience: 100_u32,
+        };
+
+        assert!(
+            beast1.beast_id != beast2.beast_id,"Different beasts should have unique IDs"
+        );
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_beast_stats_max_values() {
+        let high_level_beast = BeastStats {
+            beast_id: 1_u32,
+            attack: 999_u32,
+            defense: 999_u32,
+            speed: 999_u32,
+            level: 99_u32,
+            experience: 9999_u32,
+            next_level_experience: 10000_u32,
+        };
+
+        assert!(high_level_beast.attack > 0_u32, "Attack should be positive");
+        assert!(high_level_beast.defense > 0_u32, "Defense should be positive");
+        assert!(high_level_beast.speed > 0_u32, "Speed should be positive");
+        assert!(high_level_beast.experience < high_level_beast.next_level_experience, "Experience should be less than next level requirement");
+    }
+}

--- a/dojo/src/models/beast_status.cairo
+++ b/dojo/src/models/beast_status.cairo
@@ -16,3 +16,140 @@ pub struct BeastStatus {
     pub happiness: u32,
     pub hygiene: u32,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::BeastStatus;
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_beast_status_initialization() {
+        let beast_status = BeastStatus {
+            beast_id: 1_u32,
+            is_alive: true,
+            is_awake: true,
+            hunger: 100_u32,
+            energy: 100_u32,
+            happiness: 100_u32,
+            hygiene: 100_u32,
+        };
+
+        assert_eq!(beast_status.beast_id, 1_u32, "Beast ID should be 1");
+        assert!(beast_status.is_alive, "Beast should be alive initially");
+        assert!(beast_status.is_awake, "Beast should be awake initially");
+        assert_eq!(beast_status.hunger, 100_u32, "Initial hunger should be 100");
+        assert_eq!(beast_status.energy, 100_u32, "Initial energy should be 100");
+        assert_eq!(beast_status.happiness, 100_u32, "Initial happiness should be 100");
+        assert_eq!(beast_status.hygiene, 100_u32, "Initial hygiene should be 100");
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_beast_status_boundaries() {
+        let max_stats_beast = BeastStatus {
+            beast_id: 4_u32,
+            is_alive: true,
+            is_awake: true,
+            hunger: 100_u32,
+            energy: 100_u32,
+            happiness: 100_u32,
+            hygiene: 100_u32,
+        };
+
+        assert!(max_stats_beast.hunger <= 100_u32, "Hunger should not exceed 100");
+        assert!(max_stats_beast.energy <= 100_u32, "Energy should not exceed 100");
+        assert!(max_stats_beast.happiness <= 100_u32, "Happiness should not exceed 100");
+        assert!(max_stats_beast.hygiene <= 100_u32, "Hygiene should not exceed 100");
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_beast_unique_ids() {
+        let beast1 = BeastStatus {
+            beast_id: 1_u32,
+            is_alive: true,
+            is_awake: true,
+            hunger: 100_u32,
+            energy: 100_u32,
+            happiness: 100_u32,
+            hygiene: 100_u32,
+        };
+
+        let beast2 = BeastStatus {
+            beast_id: 2_u32,
+            is_alive: true,
+            is_awake: true,
+            hunger: 100_u32,
+            energy: 100_u32,
+            happiness: 100_u32,
+            hygiene: 100_u32,
+        };
+
+        assert!(
+            beast1.beast_id != beast2.beast_id,
+            "Different beasts should have unique IDs"
+        );
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_deceased_beast_state() {
+        let deceased_beast = BeastStatus {
+            beast_id: 5_u32,
+            is_alive: false,
+            is_awake: false,
+            hunger: 0_u32,
+            energy: 0_u32,
+            happiness: 0_u32,
+            hygiene: 0_u32,
+        };
+
+        assert!(!deceased_beast.is_alive, "Beast should be deceased");
+        assert!(!deceased_beast.is_awake, "Deceased beast should not be awake");
+        assert_eq!(deceased_beast.hunger, 0_u32, "Deceased beast should have 0 hunger");
+        assert_eq!(deceased_beast.energy, 0_u32, "Deceased beast should have 0 energy");
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_prevent_negative_stats() {
+        let low_stats_beast = BeastStatus {
+            beast_id: 6_u32,
+            is_alive: true,
+            is_awake: true,
+            hunger: 1_u32,
+            energy: 1_u32,
+            happiness: 1_u32,
+            hygiene: 1_u32,
+        };
+
+        assert!(low_stats_beast.hunger >= 0_u32, "Hunger should never be negative");
+        assert!(low_stats_beast.energy >= 0_u32, "Energy should never be negative");
+        assert!(low_stats_beast.happiness >= 0_u32, "Happiness should never be negative");
+        assert!(low_stats_beast.hygiene >= 0_u32, "Hygiene should never be negative");
+
+        assert_eq!(
+            low_stats_beast.energy, 1_u32,
+            "Energy should be maintainable at minimum value without going negative"
+        );
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_stats_lower_bound() {
+        let zero_stats_beast = BeastStatus {
+            beast_id: 7_u32,
+            is_alive: true,
+            is_awake: true,
+            hunger: 0_u32,
+            energy: 0_u32,
+            happiness: 0_u32,
+            hygiene: 0_u32,
+        };
+
+        assert_eq!(zero_stats_beast.hunger, 0_u32, "Minimum hunger should be 0");
+        assert_eq!(zero_stats_beast.energy, 0_u32, "Minimum energy should be 0");
+        assert_eq!(zero_stats_beast.happiness, 0_u32, "Minimum happiness should be 0");
+        assert_eq!(zero_stats_beast.hygiene, 0_u32, "Minimum hygiene should be 0");
+    }
+}

--- a/dojo/src/models/food.cairo
+++ b/dojo/src/models/food.cairo
@@ -11,3 +11,92 @@ pub struct Food {
     pub name: felt252,
     pub amount: u32,
 }
+
+
+#[cfg(test)]
+mod tests {
+    use super::Food;
+    use starknet::{ContractAddress, contract_address_const};
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_food_initialization() {
+        let player_address: ContractAddress = contract_address_const::<0x123>();
+        
+        let food = Food {
+            player: player_address,
+            id: 1_u8,
+            name: 'Apple',
+            amount: 5_u32,
+        };
+
+        assert_eq!(food.player, player_address, "Player address should match");
+        assert_eq!(food.id, 1_u8, "Food ID should be 1");
+        assert_eq!(food.name, 'Apple', "Food name should be 'Apple'");
+        assert_eq!(food.amount, 5_u32, "Food amount should be 5");
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_multiple_food_items() {
+        let player_address: ContractAddress = contract_address_const::<0x123>();
+        
+        let apple = Food {
+            player: player_address,
+            id: 1_u8,
+            name: 'Apple',
+            amount: 5_u32,
+        };
+
+        let banana = Food {
+            player: player_address,
+            id: 2_u8,
+            name: 'Banana',
+            amount: 3_u32,
+        };
+
+        assert_eq!(apple.player, banana.player, "Both foods should belong to same player");
+        assert!(apple.id != banana.id, "Food items should have different IDs");
+        assert!(apple.name != banana.name, "Food items should have different names");
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_food_for_different_players() {
+        let player1_address: ContractAddress = contract_address_const::<0x123>();
+        let player2_address: ContractAddress = contract_address_const::<0x456>();
+
+        let player1_food = Food {
+            player: player1_address,
+            id: 1_u8,
+            name: 'Apple',
+            amount: 5_u32,
+        };
+
+        let player2_food = Food {
+            player: player2_address,
+            id: 1_u8,
+            name: 'Apple',
+            amount: 3_u32,
+        };
+
+        assert!(player1_food.player != player2_food.player, "Foods should belong to different players");
+        assert_eq!(player1_food.id, player2_food.id, "Foods can have same ID for different players");
+        assert_eq!(player1_food.name, player2_food.name, "Foods should have same name");
+    }
+
+    #[test]
+    #[available_gas(300000)]
+    fn test_food_with_zero_amount() {
+        let player_address: ContractAddress = contract_address_const::<0x123>();
+        
+        let food = Food {
+            player: player_address,
+            id: 1_u8,
+            name: 'Apple',
+            amount: 0_u32,
+        };
+
+        assert_eq!(food.amount, 0_u32, "Food amount should be 0");
+    }
+}

--- a/dojo/src/models/player.cairo
+++ b/dojo/src/models/player.cairo
@@ -11,3 +11,73 @@ pub struct Player {
     pub address: ContractAddress, 
     pub current_beast_id: u32
 }
+
+#[cfg(test)]
+mod tests {
+    use super::Player;
+    use starknet::{ContractAddress, contract_address_const};
+    use core::traits::Into;
+
+    #[test]
+    #[available_gas(1000000)]
+    fn test_player_initialization() {
+        // Use contract_address_const to create a mock address
+        let mock_address: ContractAddress = contract_address_const::<0x123>();
+        let initial_beast_id: u32 = 1;
+
+        let player = Player {
+            address: mock_address,
+            current_beast_id: initial_beast_id,
+        };
+
+        assert_eq!(
+            player.address, 
+            mock_address, 
+            "Player address should match the initialized address"
+        );
+        assert_eq!(
+            player.current_beast_id, 
+            initial_beast_id, 
+            "Current beast ID should be 1"
+        );
+    }
+
+    #[test]
+    #[available_gas(1000000)]
+    fn test_player_with_zero_beast() {
+        let mock_address: ContractAddress = contract_address_const::<0x456>();
+        
+        let player = Player {
+            address: mock_address,
+            current_beast_id: 0,
+        };
+
+        assert_eq!(
+            player.current_beast_id, 
+            0, 
+            "Initial beast ID should be 0 for new player"
+        );
+    }
+
+    #[test]
+    #[available_gas(1000000)]
+    fn test_player_address_uniqueness() {
+        let address1: ContractAddress = contract_address_const::<0x123>();
+        let address2: ContractAddress = contract_address_const::<0x456>();
+
+        let player1 = Player {
+            address: address1,
+            current_beast_id: 1,
+        };
+
+        let player2 = Player {
+            address: address2,
+            current_beast_id: 2,
+        };
+
+        assert!(
+            player1.address != player2.address, 
+            "Players should have unique addresses"
+        );
+    }
+}

--- a/dojo/src/models/player.cairo
+++ b/dojo/src/models/player.cairo
@@ -16,7 +16,6 @@ pub struct Player {
 mod tests {
     use super::Player;
     use starknet::{ContractAddress, contract_address_const};
-    use core::traits::Into;
 
     #[test]
     #[available_gas(1000000)]

--- a/dojo/src/types/food.cairo
+++ b/dojo/src/types/food.cairo
@@ -27,3 +27,34 @@ impl IntoFoodTypeU8 of core::Into<FoodType, u8> {
     }
 }
 
+
+#[cfg(test)]
+mod tests {
+    use super::{FoodType, IntoFoodTypeFelt252, IntoFoodTypeU8};
+
+    #[test]
+    #[available_gas(1000000)]
+    fn test_food_type_into_felt252() {
+        // Test the conversion of each food type to felt252
+        let apple = FoodType::Apple;
+        let banana = FoodType::Banana;
+        let cherry = FoodType::Cherry;
+
+        assert_eq!(apple.into(), 'Apple', "FoodType::Apple should be converted to 'Apple'");
+        assert_eq!(banana.into(), 'Banana', "FoodType::Banana should be converted to 'Banana'");
+        assert_eq!(cherry.into(), 'Cherry', "FoodType::Cherry should be converted to 'Cherry'");
+    }
+
+    #[test]
+    #[available_gas(1000000)]
+    fn test_food_type_into_u8() {
+        // Test the conversion of each food type to u8
+        let apple = FoodType::Apple;
+        let banana = FoodType::Banana;
+        let cherry = FoodType::Cherry;
+
+        assert_eq!(apple.into(), 0_u8, "FoodType::Apple should be converted to 0");
+        assert_eq!(banana.into(), 1_u8, "FoodType::Banana should be converted to 1");
+        assert_eq!(cherry.into(), 2_u8, "FoodType::Cherry should be converted to 2");
+    }
+}


### PR DESCRIPTION
## Summary  
-  Closes #103 

Added unit tests across all models to ensure data integrity and proper state handling:

- FoodType: Tests for correct enum conversions to felt252 and u8
- Player: Tests for address handling and beast ID management
- Food: Tests for proper food item initialization and quantity tracking
- BeastStats: Tests for level progression and stat boundaries
- BeastStatus: Tests to prevent negative stats on decrements
- Beast: Comprehensive tests for evolution, vault states, and ID consistency

## Extras  
- Added robust validation for player addresses using contract_address_const

## Evidence

Sozo Build
<img width="793" alt="image" src="https://github.com/user-attachments/assets/38e47dab-65e5-432f-b660-18b6d16a413c" />

Sozo Test
![image](https://github.com/user-attachments/assets/434c622f-f1b6-41ed-a416-80107a45ecc0)
