### PR TITLE
Feat add clean status

### DIFF
--- a/dojo/src/constants.cairo
+++ b/dojo/src/constants.cairo
@@ -11,7 +11,7 @@ const MAX_HYGIENE: u32 = 100;
 const MAX_TAP_COUNTER: u32 = 10;
 
 // Max food amount per player
-const MAX_FOOD_AMOUNT: u32 = 10;
+const MAX_FOOD_AMOUNT: u32 = 50;
 
 // Max level as babybeast
 const MAX_BABY_LEVEL: u32 = 15;

--- a/dojo/src/lib.cairo
+++ b/dojo/src/lib.cairo
@@ -16,6 +16,7 @@ mod models {
 mod types {
     mod food;
     mod beast;
+    mod clean_status;
 }
 
 mod utils {

--- a/dojo/src/models/beast_status.cairo
+++ b/dojo/src/models/beast_status.cairo
@@ -4,6 +4,9 @@ use starknet::ContractAddress;
 // Model imports
 use babybeasts::models::beast_stats::{BeastStats};
 
+// Types imports
+use babybeasts::types::clean_status::{CleanStatus};
+
 #[derive(Drop, Serde, Debug)]
 #[dojo::model]
 pub struct BeastStatus {
@@ -15,6 +18,34 @@ pub struct BeastStatus {
     pub energy: u32,
     pub happiness: u32,
     pub hygiene: u32,
+    pub clean_status: felt252,
+}
+
+#[generate_trait]
+impl BeastStatusImpl of BeastStatusTrait {
+
+    #[inline(always)]
+    fn update_clean_status(ref self: BeastStatus, hygiene: u32){
+            if hygiene>90{
+                self.clean_status = CleanStatus::Clean.into();
+            }
+            if hygiene>70 && hygiene<90 {
+                self.clean_status = CleanStatus::SlightlyDirty.into();
+            }
+            if hygiene>50 && hygiene<70 {
+                self.clean_status = CleanStatus::Dirty.into();
+            }
+            if hygiene>30 && hygiene<50 {
+                self.clean_status = CleanStatus::VeryDirty.into();
+            }
+            if hygiene>10 && hygiene<30 {
+                self.clean_status = CleanStatus::SuperDirty.into();
+            }
+            if hygiene<10 {
+                self.clean_status = CleanStatus::Filthy.into();
+            }
+    }
+
 }
 
 #[cfg(test)]

--- a/dojo/src/models/beast_status.cairo
+++ b/dojo/src/models/beast_status.cairo
@@ -26,19 +26,19 @@ impl BeastStatusImpl of BeastStatusTrait {
 
     #[inline(always)]
     fn update_clean_status(ref self: BeastStatus, hygiene: u32){
-            if hygiene>90{
+            if hygiene>=90{
                 self.clean_status = CleanStatus::Clean.into();
             }
-            if hygiene>70 && hygiene<90 {
+            if hygiene>=70 && hygiene<90 {
                 self.clean_status = CleanStatus::SlightlyDirty.into();
             }
-            if hygiene>50 && hygiene<70 {
+            if hygiene>=50 && hygiene<70 {
                 self.clean_status = CleanStatus::Dirty.into();
             }
-            if hygiene>30 && hygiene<50 {
+            if hygiene>=30 && hygiene<50 {
                 self.clean_status = CleanStatus::VeryDirty.into();
             }
-            if hygiene>10 && hygiene<30 {
+            if hygiene>=10 && hygiene<30 {
                 self.clean_status = CleanStatus::SuperDirty.into();
             }
             if hygiene<10 {
@@ -51,6 +51,7 @@ impl BeastStatusImpl of BeastStatusTrait {
 #[cfg(test)]
 mod tests {
     use super::BeastStatus;
+    use babybeasts::types::clean_status::{CleanStatus};
 
     #[test]
     #[available_gas(300000)]
@@ -63,6 +64,7 @@ mod tests {
             energy: 100_u32,
             happiness: 100_u32,
             hygiene: 100_u32,
+            clean_status: CleanStatus::Clean.into(),
         };
 
         assert_eq!(beast_status.beast_id, 1_u32, "Beast ID should be 1");
@@ -72,6 +74,7 @@ mod tests {
         assert_eq!(beast_status.energy, 100_u32, "Initial energy should be 100");
         assert_eq!(beast_status.happiness, 100_u32, "Initial happiness should be 100");
         assert_eq!(beast_status.hygiene, 100_u32, "Initial hygiene should be 100");
+        assert_eq!(beast_status.clean_status, 'Clean', "Initial clean status should be Clean");
     }
 
     #[test]
@@ -85,12 +88,14 @@ mod tests {
             energy: 100_u32,
             happiness: 100_u32,
             hygiene: 100_u32,
+            clean_status: CleanStatus::Clean.into(),
         };
 
         assert!(max_stats_beast.hunger <= 100_u32, "Hunger should not exceed 100");
         assert!(max_stats_beast.energy <= 100_u32, "Energy should not exceed 100");
         assert!(max_stats_beast.happiness <= 100_u32, "Happiness should not exceed 100");
         assert!(max_stats_beast.hygiene <= 100_u32, "Hygiene should not exceed 100");
+        assert_eq!(max_stats_beast.clean_status, 'Clean', "Initial clean status should be Clean");
     }
 
     #[test]
@@ -104,6 +109,7 @@ mod tests {
             energy: 100_u32,
             happiness: 100_u32,
             hygiene: 100_u32,
+            clean_status: CleanStatus::Clean.into(),
         };
 
         let beast2 = BeastStatus {
@@ -114,6 +120,7 @@ mod tests {
             energy: 100_u32,
             happiness: 100_u32,
             hygiene: 100_u32,
+            clean_status: CleanStatus::Clean.into(),
         };
 
         assert!(
@@ -133,6 +140,7 @@ mod tests {
             energy: 0_u32,
             happiness: 0_u32,
             hygiene: 0_u32,
+            clean_status: CleanStatus::Clean.into(),
         };
 
         assert!(!deceased_beast.is_alive, "Beast should be deceased");
@@ -152,6 +160,7 @@ mod tests {
             energy: 1_u32,
             happiness: 1_u32,
             hygiene: 1_u32,
+            clean_status: CleanStatus::Clean.into(),
         };
 
         assert!(low_stats_beast.hunger >= 0_u32, "Hunger should never be negative");
@@ -176,11 +185,13 @@ mod tests {
             energy: 0_u32,
             happiness: 0_u32,
             hygiene: 0_u32,
+            clean_status: CleanStatus::Filthy.into(),
         };
 
         assert_eq!(zero_stats_beast.hunger, 0_u32, "Minimum hunger should be 0");
         assert_eq!(zero_stats_beast.energy, 0_u32, "Minimum energy should be 0");
         assert_eq!(zero_stats_beast.happiness, 0_u32, "Minimum happiness should be 0");
         assert_eq!(zero_stats_beast.hygiene, 0_u32, "Minimum hygiene should be 0");
+        assert_eq!(zero_stats_beast.clean_status, 'Filthy', "Minimun clean status should be Filthy");
     }
 }

--- a/dojo/src/store.cairo
+++ b/dojo/src/store.cairo
@@ -14,6 +14,7 @@ use babybeasts::models::food::{Food};
 
 // types import
 use babybeasts::types::food::{FoodType};
+use babybeasts::types::clean_status::{CleanStatus};
 
 // Constants import
 use babybeasts::constants;
@@ -343,7 +344,7 @@ impl StoreImpl of StoreTrait {
 
     #[inline(always)]
     fn new_beast_status(mut self: Store, beast_id: u32) {
-        let mut beast_stats = BeastStatus {
+        let mut beast_status = BeastStatus {
             beast_id: beast_id,
             is_alive: true,
             is_awake: true,
@@ -351,9 +352,10 @@ impl StoreImpl of StoreTrait {
             energy: 100,
             happiness: 100,
             hygiene: 100,
+            clean_status: CleanStatus::Clean.into(),
         };
 
-        self.world.write_model(@beast_stats);
+        self.world.write_model(@beast_status);
     }
 
     #[inline(always)]

--- a/dojo/src/systems/actions.cairo
+++ b/dojo/src/systems/actions.cairo
@@ -32,7 +32,7 @@ pub mod actions {
     // Model imports
     use babybeasts::models::beast::{Beast, BeastTrait};
     use babybeasts::models::beast_stats::{BeastStats};
-    use babybeasts::models::beast_status::{BeastStatus};
+    use babybeasts::models::beast_status::{BeastStatus, BeastStatusTrait};
     use babybeasts::models::player::{Player, PlayerAssert};
     use babybeasts::models::food::{Food};
     
@@ -156,6 +156,9 @@ pub mod actions {
                 if beast_status.energy == 0 || beast_status.hunger == 0 {
                     beast_status.is_alive = false;
                 }
+
+               // update beast clean status
+               beast_status.update_clean_status(beast_status.hygiene);
 
                 store.write_beast(@beast);
                 store.write_beast_status(@beast_status);
@@ -350,6 +353,9 @@ pub mod actions {
                     beast_stats.defense = beast_stats.defense + 1;
                     beast_stats.speed = beast_stats.speed + 1;
                 }
+                // update beast clean status
+                beast_status.update_clean_status(beast_status.hygiene);
+
                 store.write_beast(@beast);
                 store.write_beast_status(@beast_status);
                 store.write_beast_stats(@beast_stats);

--- a/dojo/src/tests/test_status.cairo
+++ b/dojo/src/tests/test_status.cairo
@@ -195,7 +195,76 @@ mod tests {
         assert(final_status.hygiene > decreased_status.hygiene, 'hygiene not increased');
         assert(final_status.happiness > decreased_status.happiness, 'happiness not increased');
     }
-   
+
+    #[test]
+    fn test_beast_clean_status() {
+        // Initialize test environment
+        let (actions_system, world) = actions_system_world();
+
+        cheat_caller_address(PLAYER());
+
+        // Create player and beast
+        actions_system.spawn_player();
+        actions_system.spawn(1, 1);
+        actions_system.set_current_beast(1);
+
+        // -----------------------------------------------
+        let mut counter: u32 = 0;
+        while counter < 15 {
+            actions_system.decrease_status();
+            counter = counter + 1;
+        };
+        // HYGIENE: 85
+        let status: BeastStatus = world.read_model(1);
+        assert_eq!(status.clean_status, 'SlightlyDirty', "Clean status not changed");
+
+
+        // -----------------------------------------------
+        counter = 0;
+        while counter < 20 {
+            actions_system.decrease_status();
+            counter = counter + 1;
+        };
+        // HYGIENE: 65
+        let status: BeastStatus = world.read_model(1);
+        assert_eq!(status.clean_status, 'Dirty', "Clean status not changed");
+        
+
+        // -----------------------------------------------
+        counter = 0;
+        while counter < 20 {
+            actions_system.decrease_status();
+            actions_system.feed(1); // feed beast to avoid dead
+            counter = counter + 1;
+        };
+        // HYGIENE: 45
+        let status: BeastStatus = world.read_model(1);
+        assert_eq!(status.clean_status, 'VeryDirty', "Clean status not changed");
+    
+
+        // -----------------------------------------------
+        counter = 0;
+        while counter < 20 {
+            actions_system.decrease_status();
+            actions_system.feed(2); // feed beast to avoid dead
+            counter = counter + 1;
+        };
+        // HYGIENE: 25
+        let status: BeastStatus = world.read_model(1);
+        assert_eq!(status.clean_status, 'SuperDirty', "Clean status not changed");
+        
+
+        // -----------------------------------------------
+        counter = 0;
+        while counter < 20 {
+            actions_system.decrease_status();
+            actions_system.feed(2); // feed beast to avoid dead
+            counter = counter + 1;
+        };
+        // HYGIENE: 5
+        let status: BeastStatus = world.read_model(1);
+        assert_eq!(status.clean_status, 'Filthy', "Clean status not changed");
+    }
 
     #[test]
     fn test_beast_death() {

--- a/dojo/src/types/clean_status.cairo
+++ b/dojo/src/types/clean_status.cairo
@@ -1,0 +1,57 @@
+#[derive(Copy, Drop, Serde)]
+enum CleanStatus {
+    Clean,
+    SlightlyDirty,
+    Dirty,
+    VeryDirty,
+    SuperDirty,
+    Filthy,
+    None,
+}
+
+impl IntoCleanStatusFelt252 of core::Into<CleanStatus, felt252> {
+    #[inline(always)]
+    fn into(self: CleanStatus) -> felt252 {
+        match self {
+            CleanStatus::None => '',
+            CleanStatus::Clean => 'Clean',
+            CleanStatus::SlightlyDirty => 'SlightlyDirty',
+            CleanStatus::Dirty => 'Dirty',
+            CleanStatus::VeryDirty => 'VeryDirty',
+            CleanStatus::SuperDirty => 'SuperDirty',
+            CleanStatus::Filthy => 'Filthy',
+        }
+    }
+}
+
+impl IntoCleanStatusU32 of core::Into<CleanStatus, u32> {
+    #[inline(always)]
+    fn into(self: CleanStatus) -> u32 {
+        match self {
+            CleanStatus::None => 0,
+            CleanStatus::Clean => 1,
+            CleanStatus::SlightlyDirty => 2,
+            CleanStatus::Dirty => 3,
+            CleanStatus::VeryDirty => 4,
+            CleanStatus::SuperDirty => 5,
+            CleanStatus::Filthy => 6,
+        }
+    }
+}
+
+impl IntoU32CleanStatus of core::Into<u32, CleanStatus> {
+    #[inline]
+    fn into(self: u32) -> CleanStatus {
+        let clean_status: u32 = self.into();
+        match clean_status {
+            0 =>  CleanStatus::None,
+            1 => CleanStatus::Clean,
+            2 => CleanStatus::SlightlyDirty,
+            3 => CleanStatus::Dirty,
+            4 => CleanStatus::VeryDirty,
+            5 => CleanStatus::SuperDirty,
+            6 => CleanStatus::Filthy,
+            _ =>  CleanStatus::None,
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- Closes #159 
- This PRs enhance the hygiene status of the beast by adding statuses that change in range of the hygiene going from clean to Filthy